### PR TITLE
特定のページを個別に更新・公開できる機能が欲しい

### DIFF
--- a/api/class-shifter-api.php
+++ b/api/class-shifter-api.php
@@ -41,6 +41,15 @@ class Shifter_API {
 	private $generate_url = '';
 
 	/**
+	 * Publish Single Page URL
+	 *
+	 * @since  1.0.0
+	 * @access private
+	 * @var    string    $publish_single_url    Publish single page URL
+	 */
+	private $publish_single_url = '';
+
+	/**
 	 * Terminate URL
 	 *
 	 * @since  1.0.0
@@ -119,6 +128,7 @@ class Shifter_API {
 		$this->terminate_url          = "$shifter_api/sites/$this->site_id/wordpress_site/stop";
 		$this->generate_url           = "$shifter_api/sites/$this->site_id/artifacts";
 		$this->update_active_user_url = "$shifter_api/sites/$this->site_id/wordpress_site/update_active_user";
+		$this->publish_single_url     = "$shifter_api/sites/$this->site_id/wordpress_site/pages/publish";
 		$this->refresh_url            = "$shifter_api/login";
 		$this->shifter_dashboard_url  = "https://go.getshifter.io/admin/sites/$this->site_id";
 
@@ -180,7 +190,7 @@ class Shifter_API {
 			'body'     => $body,
 		);
 
-		return wp_remote_request( $this->generate_url, $args );
+		return wp_remote_request( $this->publish_single_url, $args );
 	}
 
 	/**

--- a/api/class-shifter-api.php
+++ b/api/class-shifter-api.php
@@ -153,6 +153,37 @@ class Shifter_API {
 	}
 
 	/**
+	 * Upload Single Page
+	 *
+	 * @since 1.0.0
+	 * @param string $path Target page path.
+	 */
+	public function upload_single_page( $path ) {
+		if ( $this->access_token_is_expired() ) {
+			$this->refresh_token();
+		}
+
+		$headers = array(
+			'authorization' => $this->access_token,
+			'content-Type'  => 'application/json',
+		);
+		$body    = wp_json_encode(
+			array(
+				'siteId' => $this->site_id,
+				'path'   => $path,
+			)
+		);
+		$args    = array(
+			'method'   => 'POST',
+			'headers'  => $headers,
+			'blocking' => false,
+			'body'     => $body,
+		);
+
+		return wp_remote_request( $this->generate_url, $args );
+	}
+
+	/**
 	 * Build Args
 	 *
 	 * @since 1.0.0

--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -86,7 +86,14 @@ class Shifter_Global {
 		if ( is_user_logged_in() ) {
 			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/shifter-global.js', array( 'jquery' ), $this->version, false );
 			wp_register_script( 'sweetalert2', 'https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/7.26.11/sweetalert2.min.js', array(), '7.26.11', true );
-			wp_localize_script( 'sweetalert2', 'ajax_object', array( 'ajax_url' => admin_url( 'admin-ajax.php' ), 'nonce' => wp_create_nonce( 'shifter_ops' ) ) );
+			wp_localize_script(
+				'sweetalert2',
+				'ajax_object',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'shifter_ops' ),
+				)
+			);
 			wp_enqueue_script( 'sweetalert2' );
 		}
 	}

--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -129,8 +129,8 @@ class Shifter_Global {
 		 */
 	public function shifter_app_upload_single() {
 		check_ajax_referer( 'shifter_ops', 'security' );
-		$api  = new Shifter_API();
-		$path = isset( $_POST['path'] ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
+		$api      = new Shifter_API();
+		$path     = isset( $_POST['path'] ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
 		$response = $api->upload_single_page( $path );
 
 		if ( is_wp_error( $response ) ) {

--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -114,6 +114,18 @@ class Shifter_Global {
 		return $api->generate_wp_app();
 	}
 
+		/**
+		 * Send Upload Single Page Request
+		 *
+		 * @since  1.0.0
+		 * @return mixed
+		 */
+	public function shifter_app_upload_single() {
+		$api = new Shifter_API();
+		$path = isset( $_POST['path'] ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
+		return $api->upload_single_page( $path );
+	}
+
 	/**
 	 * Shifter Admin Bar
 	 *
@@ -151,7 +163,16 @@ class Shifter_Global {
 			'meta'   => array( 'class' => $local_class ),
 		);
 
+		$shifter_support_upload_single = array(
+			'id'     => 'shifter_support_upload_single',
+			'title'  => 'Upload Single Page',
+			'parent' => 'shifter',
+			'href'   => '#',
+			'meta'   => array( 'class' => $local_class ),
+		);
+
 		$wp_admin_bar->add_menu( $shifter_support_back_to_shifter_dashboard );
+		$wp_admin_bar->add_menu( $shifter_support_upload_single );
 		if ( ! getenv( 'SHIFTER_DISABLE_GENERATE' ) ) {
 			$wp_admin_bar->add_menu( $shifter_support_generate );
 		}

--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -86,7 +86,7 @@ class Shifter_Global {
 		if ( is_user_logged_in() ) {
 			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/shifter-global.js', array( 'jquery' ), $this->version, false );
 			wp_register_script( 'sweetalert2', 'https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/7.26.11/sweetalert2.min.js', array(), '7.26.11', true );
-			wp_localize_script( 'sweetalert2', 'ajax_object', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
+			wp_localize_script( 'sweetalert2', 'ajax_object', array( 'ajax_url' => admin_url( 'admin-ajax.php' ), 'nonce' => wp_create_nonce( 'shifter_ops' ) ) );
 			wp_enqueue_script( 'sweetalert2' );
 		}
 	}
@@ -121,7 +121,8 @@ class Shifter_Global {
 		 * @return mixed
 		 */
 	public function shifter_app_upload_single() {
-		$api = new Shifter_API();
+		check_ajax_referer( 'shifter_ops', 'security' );
+		$api  = new Shifter_API();
 		$path = isset( $_POST['path'] ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
 		return $api->upload_single_page( $path );
 	}

--- a/global/js/shifter-global.js
+++ b/global/js/shifter-global.js
@@ -29,11 +29,11 @@
    * practising this, we should strive to set a better example in our own work.
    */
 
-  function call_shifter_operation(action) {
+  function call_shifter_operation(action, extraData) {
     $.ajax({
       method: "POST",
       url: ajax_object.ajax_url,
-      data: { action: action }
+      data: Object.assign({ action: action }, extraData || {})
     }).done(response => {
       console.log(response);
       console.log(ajax_object.ajax_url);
@@ -83,6 +83,29 @@
     });
   }
 
+  function upload_single_page() {
+    const currentUrl = window.location.href;
+    const path = window.location.pathname;
+    swal({
+      title: "Upload Single Page?",
+      text: `Only this page will be uploaded.\n${currentUrl}`,
+      showCancelButton: true,
+      confirmButtonColor: "#bc4e9c",
+      cancelButtonColor: "#333",
+      confirmButtonText: "Upload",
+      padding: "3em"
+    }).then(result => {
+      if (result.value) {
+        call_shifter_operation("shifter_app_upload_single", { path: path });
+        swal(
+          "Upload started",
+          "Please check the Shifter dashboard",
+          "success"
+        );
+      }
+    });
+  }
+
   $(document).on("click", "#wp-admin-bar-shifter_support_generate", function() {
     generate_artifact();
   });
@@ -92,6 +115,14 @@
     "#wp-admin-bar-shifter_support_terminate",
     function() {
       terminate_app();
+    }
+  );
+
+  $(document).on(
+    "click",
+    "#wp-admin-bar-shifter_support_upload_single",
+    function() {
+      upload_single_page();
     }
   );
 })(jQuery);

--- a/global/js/shifter-global.js
+++ b/global/js/shifter-global.js
@@ -33,7 +33,7 @@
     $.ajax({
       method: "POST",
       url: ajax_object.ajax_url,
-      data: Object.assign({ action: action }, extraData || {})
+      data: Object.assign({ action: action, security: ajax_object.nonce }, extraData || {})
     }).done(response => {
       console.log(response);
       console.log(ajax_object.ajax_url);

--- a/includes/class-shifter.php
+++ b/includes/class-shifter.php
@@ -222,6 +222,9 @@ class Shifter {
 
 		// Terminate Container Request.
 		$this->loader->add_action( 'wp_ajax_shifter_app_terminate', $plugin_global, 'shifter_app_terminate' );
+
+		// Upload Single Page Request.
+		$this->loader->add_action( 'wp_ajax_shifter_app_upload_single', $plugin_global, 'shifter_app_upload_single' );
 	}
 
 	/**


### PR DESCRIPTION
**global/class-shifter-global.php**
管理バー項目 shifter_support_upload_single を追加
AJAXハンドラー shifter_app_upload_single を追加（check_ajax_referer で nonce 検証、成功/失敗を wp_send_json_* で返却）
enqueue_scripts で ajax_object = { ajax_url, nonce } をローカライズ
**includes/class-shifter.php**
wp_ajax_shifter_app_upload_single を登録
**api/class-shifter-api.php**
publish_single_url を追加（/sites/{site_id}/wordpress_site/pages/publish）
upload_single_page($path) を実装（Body: { siteId, path }、認証ヘッダ付）
**global/js/shifter-global.js**
クリックで SweetAlert 確認→AJAX 送信（nonce 同送）
成功時は bucket/key/statusCode/... をダイアログ表示、失敗時はエラー内容を表示