### PR TITLE
fix(global): Upload Single Pageのpath正規化で日本語URLの`//`送信を修正

### DIFF
--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -186,8 +186,9 @@ class Shifter_Global {
 			);
 			exit;
 		}
-		$api  = new Shifter_API();
-		$path = isset( $_POST['path'] ) ? sanitize_text_field( wp_unslash( $_POST['path'] ) ) : '';
+		$api      = new Shifter_API();
+		$raw_path = isset( $_POST['path'] ) ? wp_unslash( $_POST['path'] ) : '';
+		$path     = $this->normalize_upload_single_path( $raw_path );
 		// Log request meta (path only; no sensitive data).
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( "[Shifter] upload_single: request path={$path}" );
@@ -227,6 +228,45 @@ class Shifter_Global {
 			$http_status ? $http_status : 500
 		);
 		exit;
+	}
+
+	/**
+	 * Normalize upload-single path for Shifter API.
+	 *
+	 * Input may be a full URL or pathname and may include percent-encoded UTF-8.
+	 * Output is always a decoded UTF-8 path beginning with '/'.
+	 *
+	 * @param mixed $raw_path Raw path received from request.
+	 * @return string
+	 */
+	private function normalize_upload_single_path( $raw_path ) {
+		if ( ! is_string( $raw_path ) ) {
+			return '/';
+		}
+
+		$path = trim( $raw_path );
+		if ( '' === $path ) {
+			return '/';
+		}
+
+		$parsed = wp_parse_url( $path );
+		if ( is_array( $parsed ) && isset( $parsed['path'] ) && is_string( $parsed['path'] ) ) {
+			$path = $parsed['path'];
+		}
+
+		$path = wp_kses_no_null( $path );
+		$path = preg_replace( '/[\x00-\x1F\x7F]/u', '', $path );
+		if ( ! is_string( $path ) || '' === $path ) {
+			return '/';
+		}
+
+		$path = '/' . ltrim( $path, '/' );
+		$path = preg_replace( '#/+#', '/', $path );
+		if ( ! is_string( $path ) || '' === $path ) {
+			return '/';
+		}
+
+		return $path;
 	}
 
 	/**

--- a/global/class-shifter-global.php
+++ b/global/class-shifter-global.php
@@ -187,8 +187,11 @@ class Shifter_Global {
 			exit;
 		}
 		$api      = new Shifter_API();
-		$raw_path = isset( $_POST['path'] ) ? wp_unslash( $_POST['path'] ) : '';
-		$path     = $this->normalize_upload_single_path( $raw_path );
+		$raw_path = filter_input( INPUT_POST, 'path', FILTER_UNSAFE_RAW, FILTER_NULL_ON_FAILURE );
+		if ( ! is_string( $raw_path ) ) {
+			$raw_path = '';
+		}
+		$path = $this->normalize_upload_single_path( $raw_path );
 		// Log request meta (path only; no sensitive data).
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( "[Shifter] upload_single: request path={$path}" );

--- a/global/js/shifter-global.js
+++ b/global/js/shifter-global.js
@@ -136,7 +136,7 @@
 
   function upload_single_page() {
     const currentUrl = window.location.href;
-    const path = window.location.pathname;
+    const path = normalize_publish_path(window.location.pathname);
     swal({
       title: "Upload Single Page?",
       text: `Only this page will be uploaded.\n${currentUrl}`,
@@ -227,6 +227,25 @@
       }
       swal("Upload completed", "Upload succeeded.", "success");
     });
+  }
+
+  function normalize_publish_path(rawPath) {
+    let path = typeof rawPath === "string" ? rawPath : "/";
+
+    if (!path) {
+      return "/";
+    }
+
+    try {
+      path = decodeURI(path);
+    } catch (e) {}
+
+    path = path.replace(/\/{2,}/g, "/");
+    if (!path.startsWith("/")) {
+      path = `/${path}`;
+    }
+
+    return path;
   }
 
   function setup_presence_refresh() {

--- a/shifter.php
+++ b/shifter.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Shifter
  * Plugin URI:        https://github.com/getshifter/shifter-wp-mu
  * Description:       Helper functions for WordPress sites on Shifter.
- * Version:           1.3.5
+ * Version:           1.3.6
  * Author:            DigitalCube
  * Author URI:        https://www.getshifter.io
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SHIFTER_VERSION', '1.3.5' );
+define( 'SHIFTER_VERSION', '1.3.6' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
`sanitize_text_field`で`path`が崩れる経路を廃止し、PHP側でURLパス正規化を追加。 フロント側も`decodeURI`を使ったパス整形に統一して、`pages/publish`へ安定して送信できるようにする。